### PR TITLE
docs: update documentation for archived NixOS host and add linting

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,5 @@
+config:
+  line-length: false
+  first-line-heading: false
+  ol-prefix:
+    style: ordered

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,15 @@ darwin-rebuild switch --flake .
 # Format all Nix files (alejandra)
 nix fmt
 
+# Format specific files
+nix fmt -- file1.nix file2.nix
+
+# Lint all Markdown files
+npx markdownlint-cli2 "**/*.md"
+
+# Lint and auto-fix Markdown files
+npx markdownlint-cli2 --fix "**/*.md"
+
 # Update all flake inputs to latest
 nix flake update
 
@@ -26,11 +35,11 @@ nix run nix-darwin -- switch --flake ~/nix-config
 
 ## Architecture
 
-This is a **Nix flake** for configuring a macOS M2 MacBook Air (aarch64-darwin). It composes three layers:
+This repository contains an active **Nix flake** for configuring a macOS M2 MacBook Air (aarch64-darwin) plus archived NixOS/media configuration. The active system uses two layers, plus an archive for future reference:
 
 1. **nix-darwin** (`darwin/`, `hosts/laptop/`) — macOS system-level settings, Homebrew packages, fonts, and system environment
 2. **home-manager** (`home/`) — user-level dotfiles and application configuration via the `common` module namespace
-3. **Secrets** (`secrets/`) — `agenix`-managed `.age` encrypted secrets, currently scoped to a separate NixOS media host
+3. **Archive** (`archive/`) — archived NixOS/media host configuration and `agenix` secrets retained for future reference, not part of the active flake outputs
 
 ### Directory Structure
 
@@ -42,12 +51,15 @@ This is a **Nix flake** for configuring a macOS M2 MacBook Air (aarch64-darwin).
   - `cli/` — fish, zsh, fzf, zellij, apps (CLI tools)
   - `karabiner/`, `hammerspoon/` — macOS keyboard/automation
   - Individual files: git, neovim, wezterm, ssh, yazi, kitty, alacritty, firefox
-- `nixos/modules/` — NixOS service modules for the media server host (not active in current flake outputs)
-- `secrets/secrets.nix` — agenix secret declarations keyed to the media host's SSH public key
+- `archive/README.md` — archive scope and reactivation notes
+- `archive/hosts/media/` — archived media host configuration
+- `archive/nixos/` — archived NixOS modules retained for future reference
+- `archive/secrets/` — archived agenix secret declarations and encrypted secret files for the media host
 
 ### Module Pattern
 
 All reusable modules use a consistent `common.<name>.enable = true/false` option pattern. To add a new home-manager module:
+
 1. Create `home/modules/<name>.nix` defining `options.common.<name>.enable` and `config = mkIf cfg.enable { ... }`
 2. Import it in `home/modules/default.nix`
 3. Enable it in `home/home.nix`
@@ -96,6 +108,7 @@ Use `lib.mkOption` with explicit `type` and `description` for any option beyond 
 ### Formatting and commits
 
 - Always run `nix fmt` before committing — alejandra is the formatter.
+- Always run `npx markdownlint-cli2 "**/*.md"` before committing changes to Markdown files. Config is in `.markdownlint-cli2.yaml`.
 - Commit messages follow **Conventional Commits**: `fix(scope): message` or `feat(scope): message` (match the style in the git log).
 - Run `darwin-rebuild build --flake .` before `darwin-rebuild switch --flake .` to catch errors without changing the running system.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
-[![deploy-flake](https://github.com/mich-murphy/nix-config/actions/workflows/deploy-nixos.yml/badge.svg?branch=main)](https://github.com/mich-murphy/nix-config/actions/workflows/deploy-nixos.yml)
+[![build-macos](https://github.com/mich-murphy/nix-config/actions/workflows/build-macos.yml/badge.svg?branch=main)](https://github.com/mich-murphy/nix-config/actions/workflows/build-macos.yml)
 
 # Nix-Darwin Configuration Flake
 
 ![screenshot](./assets/screenshot.png)
 ![screenshot-browser](./assets/screenshot-2.png)
+
+## Repository Scope
+
+The active flake currently exposes only `darwinConfigurations.macbook` for the
+macOS laptop configuration.
+
+The former media/NixOS system has been archived under `archive/` for future
+reference and is not part of the active flake outputs.
 
 ## Contents
 
@@ -46,33 +54,33 @@ using the following references:
 1. Install Nix on the target machine using Determinate Systems installer
    (enables flakes by default amongst other benefits):
 
-```bash
-curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
-| sh -s -- install
-```
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+   | sh -s -- install
+   ```
 
 2. Some packages aren't yet available for Darwin in Nix - for these we need to
    configure Homebrew
 
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-brew analytics off
-```
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   brew analytics off
+   ```
 
 3. Install Git, clone the repository and run the first build of the Flake to
    make darwin commands available
 
-```bash
-nix-env -iA nixpkgs.git
-git clone https://github.com/mich-murphy/nix-config
-nix run nix-darwin -- switch --flake ~/nix-config
-```
+   ```bash
+   nix-env -iA nixpkgs.git
+   git clone https://github.com/mich-murphy/nix-config
+   nix run nix-darwin -- switch --flake ~/nix-config
+   ```
 
 4. In future you can rebuild and activate the Flake using the following command
 
-```bash
-darwin-rebuild switch --flake .
-```
+   ```bash
+   darwin-rebuild switch --flake .
+   ```
 
 ## Understanding Nix
 
@@ -84,9 +92,11 @@ There are several components that are referred to regarding Nix:
    allows for installation of applications and dependencies
 3. NixOS is an operating system, which is entirely configured using the Nix language.
 
-The above configuration is for a Macbook Air M2 running MacOS, which does not
-currently have a stable version of NixOS available. All configuration is created
-by using the Nix package manager, with some additional options provided by Nix-Darwin.
+The active configuration in this flake is for a Macbook Air M2 running MacOS.
+The former media/NixOS configuration is retained under `archive/` for future
+reference and is not built by the current flake outputs. All active
+configuration is created by using the Nix package manager, with some additional
+options provided by Nix-Darwin.
 
 For further information regarding Nix refer to the below resources:
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,204 @@
+# TODO
+
+Reviewed: 2026-04-06
+
+This checklist captures improvements found while reviewing the
+repository against the official manuals:
+
+- [Nix Reference Manual](https://nixos.org/manual/nix/stable)
+- [Nixpkgs Manual](https://nixos.org/manual/nixpkgs/stable)
+- [NixOS Manual](https://nixos.org/manual/nixos/stable)
+- [nix-darwin Manual](https://nix-darwin.github.io/nix-darwin/manual/index.html)
+- [Home Manager Manual](https://nix-community.github.io/home-manager/)
+- [Home Manager Options Reference](https://nix-community.github.io/home-manager/options.xhtml)
+
+These are tracking items for follow-up work; not every item is an
+immediate bug. They are ordered by expected project impact and by how
+far the current setup diverges from the recommended declarative/
+module-driven approach.
+
+## Highest priority
+
+- [x] **Make the repository scope explicit and the flake buildable for
+  every retained host**
+  - The active flake now exposes only `darwinConfigurations.macbook`.
+  - The inactive media/NixOS tree has been moved under `archive/` and
+    is no longer part of the active flake outputs.
+  - This keeps the retained active scope buildable while preserving the
+    old host for future reference.
+  - Manual focus: flakes are intended to package Nix code with declared
+    inputs and outputs in a reproducible way.
+
+- [ ] **Remove the fake terminal package overlay hack**
+  - `flake.nix` defines `fakepkg`, and Home Manager terminal modules
+    currently use it:
+    - `home/modules/wezterm.nix`
+    - `home/modules/alacritty.nix`
+    - `home/modules/kitty.nix`
+  - This bypasses Home Manager module expectations instead of using a
+    real package or managing config files separately from installation.
+  - Prefer one clear model:
+    1. install the terminal with Nix and let Home Manager manage it
+       normally; or
+    2. keep installation in Homebrew and manage only config files via
+       `xdg.configFile` / `home.file`.
+  - Manual focus: Nixpkgs overlays, nix-darwin Homebrew management, and
+    Home Manager program modules.
+
+- [ ] **Make the Home Manager Neovim setup declarative and
+  self-contained**
+  - `home/modules/neovim.nix` notes that `~/.config/nvim` must be
+    cloned manually outside Nix.
+  - This makes the active Home Manager configuration incomplete and
+    undermines the reproducibility Home Manager is meant to provide.
+  - Bring the Neovim config into this repository, reference it as a
+    flake input, or manage it via `xdg.configFile` / `home.file`.
+  - Manual focus: Home Manager-managed files and declarative home
+    environments.
+
+## Testing
+
+Testing work is grouped here so module contracts, build coverage, and
+system verification can be tracked together.
+
+- [x] **Add `flake checks` for every retained system and activation
+  package**
+  - The repository now has a `checks` output covering the retained
+    active system.
+  - Current checks evaluate and build:
+    - `darwinConfigurations.macbook`
+    - the Home Manager activation package used by the laptop
+      configuration
+  - This is the baseline gate for `nix flake check` locally and in CI.
+  - Manual focus: `nix flake check` and flake output validation.
+
+- [ ] **Add assertion coverage for retained reusable modules**
+  - Assertions are currently inconsistent:
+    - most Home Manager modules have none
+    - both Darwin modules have none
+  - Add assertions for module invariants such as:
+    - mutually exclusive terminal modules (`wezterm`, `kitty`,
+      `alacritty`)
+    - `darwin/modules/skhd.nix` requiring `common.yabai.enable`
+  - Every retained reusable module should have explicit checks for the
+    invalid combinations it knows how to reject.
+  - Manual focus: module option contracts and assertion-based
+    validation.
+
+- [ ] **Add module evaluation tests with positive and negative cases**
+  - Add lightweight Nix tests that instantiate reusable Darwin and Home
+    Manager modules in isolation.
+  - Positive tests should verify expected configuration output for valid
+    option combinations.
+  - Negative tests should verify that invalid combinations fail with the
+    intended assertion message.
+  - This is especially important for reusable modules under
+    `darwin/modules/` and `home/modules/`.
+  - Manual focus: module evaluation and assertion behaviour.
+
+- [ ] **Add system-level tests that verify installed applications and
+  generated settings**
+  - Current validation proves the active Darwin system and Home Manager
+    activation package can be built.
+  - Add checks that inspect built system outputs and generated config
+    files to confirm expected settings are present for key applications
+    and shells, for example:
+    - Home Manager generated configs for `git`, `ssh`, shells, `yazi`,
+      terminals, and `karabiner`
+    - nix-darwin generated Homebrew/Brewfile state for declared casks,
+      brews, and MAS apps
+    - system package presence in retained system closures
+  - Manual focus: system tests and generated configuration
+    verification.
+
+- [ ] **Run the full test suite in CI without mutating tracked
+  configuration**
+  - Current GitHub Actions only builds the macOS configuration and
+    rewrites tracked files with `sed` to adapt usernames for the
+    runner.
+  - Replace that with proper CI-specific config or checks so CI runs the
+    same declarative test targets defined by the flake.
+  - CI should run at least formatting, `nix flake check`, and retained
+    system build/tests.
+  - Manual focus: reproducible CI validation.
+
+## High priority
+
+- [ ] **Prefer nix-darwin's built-in Nix maintenance options over a
+  custom launchd GC agent**
+  - `hosts/laptop/default.nix` defines `launchd.agents.nix-gc`
+    manually.
+  - nix-darwin already provides typed, documented `nix.gc.*` and
+    `nix.optimise.*` options.
+  - If these are compatible with the Determinate installer setup,
+    migrate to them; otherwise document why the custom launchd agent is
+    still required.
+  - Manual focus: nix-darwin `nix.gc` / `nix.optimise` options.
+
+- [ ] **Replace duplicated shell PATH and hook setup with shared Home
+  Manager session options**
+  - `/opt/homebrew/bin` is added separately in
+    `home/modules/cli/fish.nix` and `home/modules/cli/zsh.nix`.
+  - `programs.direnv.enableZshIntegration = true` is already set in
+    `home/modules/cli/apps.nix`, but `home/modules/cli/zsh.nix` also
+    runs `eval "$(direnv hook zsh)"` manually.
+  - Prefer `home.sessionPath` / `home.sessionVariables` for shared
+    environment state and let Home Manager modules manage their shell
+    hooks once.
+  - Manual focus: Home Manager session variables/path and shell
+    integrations.
+
+- [ ] **Replace Home Manager SSH `extraOptions` with typed SSH options
+  where available**
+  - `home/modules/ssh.nix` uses `extraOptions` for `IdentityAgent` and
+    `HashKnownHosts`, even though Home Manager exposes typed options
+    such as `identityAgent` and `hashKnownHosts`.
+  - Prefer structured options where available, leaving `extraOptions`
+    only for settings that have no first-class module option.
+  - Manual focus: Home Manager `programs.ssh.matchBlocks` options.
+
+- [ ] **Set `system.configurationRevision` on the Darwin
+  configuration**
+  - The nix-darwin manual exposes `system.configurationRevision` for
+    recording which flake revision produced the current system.
+  - Set it from the repository revision so deployed systems are easier
+    to audit and trace back to source.
+  - Manual focus: nix-darwin system version metadata.
+
+- [ ] **Review Karabiner file deployment and keep the activation copy
+  only if mutability is required**
+  - `home/modules/karabiner/default.nix` uses `home.activation` to copy
+    `karabiner.json` into place.
+  - Prefer `xdg.configFile."karabiner/karabiner.json".source = ...` if a
+    normal declarative file is sufficient.
+  - Keep the current copy-based approach only if Karabiner needs a
+    writable/mutable config file in practice.
+  - Manual focus: Home Manager managed files and activation DAG usage.
+
+## Low priority / cleanup
+
+- [ ] **Review duplicated `allowUnfree` configuration**
+  - `hosts/laptop/default.nix` sets
+    `nixpkgs.config.allowUnfree = true`.
+  - `home/home.nix` also writes `~/.config/nixpkgs/config.nix` with
+    `allowUnfree = true`.
+  - Decide whether the per-user config file is still needed, document
+    why it exists if it is, or consolidate to reduce drift between
+    declarative and ad hoc package evaluation.
+  - Manual focus: Nixpkgs global configuration.
+
+- [ ] **Refresh README bootstrap guidance so it matches the actual
+  flake**
+  - README now reflects the archived media/NixOS tree, but it still has
+    stale bootstrap and reference details.
+  - Re-check the bootstrap/install commands against the current manuals
+    and the repo's actual outputs.
+  - While touching docs, replace the moved nix-darwin manual link and
+    fix any stale workflow or CI references.
+  - Manual focus: flake-based workflows and repository documentation
+    alignment.
+
+## Completed
+
+- [x] Repository review against official Nix, Nixpkgs, NixOS,
+  nix-darwin, and Home Manager manuals completed (2026-04-06)


### PR DESCRIPTION
## Summary
- Updates documentation to reflect the archived NixOS host
- Adds linting configuration

## Test plan
- [ ] Verify documentation accuracy
- [ ] Confirm linting runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)